### PR TITLE
feat: make ansible-rosa repo a proper ansible collection

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,0 +1,22 @@
+namespace: mobb
+name: rosa
+version: 1.0.0
+readme: README.md
+authors:
+  - Paul Czarkowski <pczarkow@redhat.com>
+  - Connor Wooley <cwooley@redhat.com>
+  - Dustin Scott <dscott@redhat.com>
+description: Collection of various Ansible roles to manage ROSA infrastructure.
+license_file: LICENSE
+tags:
+  - ROSA
+  - MOBB
+  - OpenShift
+  - AWS
+  - Red Hat
+dependencies: {}
+repository: https://github.com/rh-mobb/ansible-rosa
+documentation: https://github.com/rh-mobb/ansible-rosa
+homepage: https://github.com/rh-mobb/ansible-rosa
+issues: https://github.com/rh-mobb/ansible-rosa/issues
+build_ignore: []

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,52 @@
+---
+# Collections must specify a minimum required ansible version to upload
+# to galaxy
+# requires_ansible: '>=2.9.10'
+
+# Content that Ansible needs to load from another location or that has
+# been deprecated/removed
+# plugin_routing:
+#   action:
+#     redirected_plugin_name:
+#       redirect: ns.col.new_location
+#     deprecated_plugin_name:
+#       deprecation:
+#         removal_version: "4.0.0"
+#         warning_text: |
+#           See the porting guide on how to update your playbook to
+#           use ns.col.another_plugin instead.
+#     removed_plugin_name:
+#       tombstone:
+#         removal_version: "2.0.0"
+#         warning_text: |
+#           See the porting guide on how to update your playbook to
+#           use ns.col.another_plugin instead.
+#   become:
+#   cache:
+#   callback:
+#   cliconf:
+#   connection:
+#   doc_fragments:
+#   filter:
+#   httpapi:
+#   inventory:
+#   lookup:
+#   module_utils:
+#   modules:
+#   netconf:
+#   shell:
+#   strategy:
+#   terminal:
+#   test:
+#   vars:
+
+# Python import statements that Ansible needs to load from another location
+# import_redirection:
+#   ansible_collections.ns.col.plugins.module_utils.old_location:
+#     redirect: ansible_collections.ns.col.plugins.module_utils.new_location
+
+# Groups of actions/modules that take a common set of options
+# action_groups:
+#   group_name:
+#     - module1
+#     - module2


### PR DESCRIPTION
This allows us to use the provided roles as part of a collection, rather than copying, pasting or custom scripting the download to a subpath