### PR TITLE
Add conditional option to create cluster-admin

### DIFF
--- a/create-cluster.yaml
+++ b/create-cluster.yaml
@@ -24,6 +24,7 @@
     - name: roles/dns_resolver_create
       when: rosa_tgw_enabled | bool
     - name: roles/create_admin
+      when: rosa_create_admin | bool
     - name: roles/finish
 
 

--- a/environment/cicd-demo/group_vars/all.yaml
+++ b/environment/cicd-demo/group_vars/all.yaml
@@ -12,3 +12,5 @@ rosa_max_replicas: 4
 rosa_version: 4.12.12
 rosa_region: us-east-1
 rosa_vpc_cidr: "10.0.0.0/16"
+
+rosa_create_admin: true

--- a/environment/default/group_vars/all.yaml
+++ b/environment/default/group_vars/all.yaml
@@ -12,3 +12,5 @@ rosa_max_replicas: 4
 rosa_version: 4.10.3
 rosa_region: us-east-1
 rosa_vpc_cidr: "10.0.0.0/16"
+
+rosa_create_admin: true

--- a/environment/hcp/group_vars/all.yaml
+++ b/environment/hcp/group_vars/all.yaml
@@ -12,3 +12,5 @@ rosa_hosted_cp: true
 rosa_version: 4.12.21
 rosa_region: us-east-1
 rosa_vpc_cidr: "10.0.0.0/20"
+
+rosa_create_admin: true

--- a/environment/multi-az/group_vars/all.yaml
+++ b/environment/multi-az/group_vars/all.yaml
@@ -9,3 +9,5 @@ rosa_multi_az: true
 rosa_version: 4.11.6
 rosa_region: us-east-1
 rosa_vpc_cidr: "172.28.80.0/20"
+
+rosa_create_admin: true

--- a/environment/private-link/group_vars/all.yaml
+++ b/environment/private-link/group_vars/all.yaml
@@ -12,3 +12,5 @@ rosa_vpc_cidr: "10.0.0.0/16"
 # jumphost_instance_type: t1.micro
 jumphost_instance_type: t2.nano
 # jumphost_instance_type: m4.large
+
+rosa_create_admin: true

--- a/environment/transit-gateway-egress/group_vars/all.yaml
+++ b/environment/transit-gateway-egress/group_vars/all.yaml
@@ -26,6 +26,8 @@ jumphost_instance_type: t2.micro
 
 proxy_enabled: true
 
+rosa_create_admin: true
+
 ## don't set these and let it use your already logged in accounts
 # aws_access_key_id:
 # aws_secret_access_key:

--- a/roles/create_admin/tasks/main.yml
+++ b/roles/create_admin/tasks/main.yml
@@ -9,6 +9,7 @@
   failed_when: (_create_admin.rc != 0) and ("already has an admin" not in _create_admin.stderr)
   changed_when: _create_admin.rc == 0
   no_log: true
+  when: rosa_create_admin
 
 
 

--- a/roles/create_admin/tasks/main.yml
+++ b/roles/create_admin/tasks/main.yml
@@ -9,8 +9,6 @@
   failed_when: (_create_admin.rc != 0) and ("already has an admin" not in _create_admin.stderr)
   changed_when: _create_admin.rc == 0
   no_log: true
-  when: rosa_create_admin
-
 
 
 

--- a/roles/finish/tasks/main.yml
+++ b/roles/finish/tasks/main.yml
@@ -35,6 +35,17 @@
         oc login {{ _cluster_info.cluster.api.url }} \
           --username cluster-admin --password {{ rosa_admin_password }}
   delegate_to: localhost
+  when: rosa_create_admin
+
+- debug:
+    msg: |
+      Cluster API: {{ _cluster_info.cluster.api.url }}
+      Cluster Console: {{ _cluster_info.cluster.console.url }}
+
+      Create a cluster-admin user:
+        rosa create admin --cluster {{ cluster_name }}
+  delegate_to: localhost
+  when: not rosa_create_admin
 
 - debug:
     msg: |

--- a/roles/finish/tasks/main.yml
+++ b/roles/finish/tasks/main.yml
@@ -35,7 +35,7 @@
         oc login {{ _cluster_info.cluster.api.url }} \
           --username cluster-admin --password {{ rosa_admin_password }}
   delegate_to: localhost
-  when: rosa_create_admin
+  when: rosa_create_admin | bool
 
 - debug:
     msg: |
@@ -45,7 +45,7 @@
       Create a cluster-admin user:
         rosa create admin --cluster {{ cluster_name }}
   delegate_to: localhost
-  when: not rosa_create_admin
+  when: not rosa_create_admin | bool
 
 - debug:
     msg: |


### PR DESCRIPTION
Allow a user to prevent the hardcoding and automatic creation of the cluster-admin user

- Added bool variable `rosa_create_admin`, defaulted to true to not break current implementation
- Added conditional `when: rosa_create_admin` bool operator to run the create_admin task
