### PR TITLE
--ignore-certs for ansible-galaxy collection install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ EXTRA_VARS ?= --extra-vars "cluster_name=$(CLUSTER_NAME)"
 VIRTUALENV ?= "./virtualenv/"
 ANSIBLE = $(VIRTUALENV)/bin/ansible-playbook $(EXTRA_VARS)
 
+IGNORE_CERTS ?= false
+IGNORE_CERTS_OPTION=
+ifeq ($(IGNORE_CERTS), true)
+IGNORE_CERTS_OPTION = --ignore-certs
+endif
 
 help:
 	@echo GLHF
@@ -17,7 +22,7 @@ virtualenv:
 		. $(VIRTUALENV)/bin/activate
 		pip install pip --upgrade
 		LC_ALL=en_US.UTF-8 $(VIRTUALENV)/bin/pip3 install -r requirements.txt #--use-feature=2020-resolver
-		$(VIRTUALENV)/bin/ansible-galaxy collection install -r requirements.yml --ignore-certs
+		$(VIRTUALENV)/bin/ansible-galaxy collection install -r requirements.yml $(IGNORE_CERTS_OPTION)
 
 docker.image:
 	docker build -t quay.io/pczar/ansible-rosa .

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ virtualenv:
 		. $(VIRTUALENV)/bin/activate
 		pip install pip --upgrade
 		LC_ALL=en_US.UTF-8 $(VIRTUALENV)/bin/pip3 install -r requirements.txt #--use-feature=2020-resolver
-		$(VIRTUALENV)/bin/ansible-galaxy collection install -r requirements.yml
+		$(VIRTUALENV)/bin/ansible-galaxy collection install -r requirements.yml --ignore-certs
 
 docker.image:
 	docker build -t quay.io/pczar/ansible-rosa .

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ cd ansible-rosa
 make virtualenv
 ```
 
+### If you encounter SSL Certificate errors with ansible-galaxy and want to bypass certificate validation. USE WITH CAUTION!
+
+```
+IGNORE_CERTS=true make virtualenv
+```
+
 ## Deploy a Cluster
 
 ### Basic STS single AZ cluster


### PR DESCRIPTION
`make virtualenv` would error when hitting the ansible-galaxy collection install step due to an unfamiliar certs error. Ignoring the certs allows the install to proceed. If there is a better way to fix this I would love to learn how.