### PR TITLE
Account roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ansible-rosa
 
-*******************************************************************
-* 							          *
-*  This project is provided as-is, and is not an official or      *
-*  Supported Red Hat project. We will happily accept issues and   *
-*  Pull Requests and provide basic OSS level community support    *
-*******************************************************************
+				                                      
+  This project is provided as-is, and is not an official or      
+  Supported Red Hat project. We will happily accept issues and   
+  Pull Requests and provide basic OSS level community support 
+
+***
 
 This project contains a set of modules for working with ROSA as well as some example playbooks.
 

--- a/delete-cluster.yaml
+++ b/delete-cluster.yaml
@@ -15,7 +15,9 @@
     #       fqdn: "{{ rosa_custom_domain_vars.fqdn }}"
     - name: roles/cluster_delete
     - name: roles/account_roles_delete
-      when: rosa_sts | bool
+      when: 
+        - rosa_sts | bool
+        - delete_account_roles
     - name: roles/jumphost_delete
       when:
         - (rosa_private or rosa_private_link) or

--- a/environment/private-link/group_vars/all.yaml
+++ b/environment/private-link/group_vars/all.yaml
@@ -1,13 +1,13 @@
 cluster_name: ansible-rosa-v1
 
-rosa_private_link: true
-rosa_sts: true
+#rosa_private_link: true
+#rosa_sts: true
 
 #set to false if you do not want to delete the account roles. Useful if different ROSA are installed using the same AWS account. Default to false (all the account roles are deleted)
 #delete_account_roles: false
 
 #uncomment to add a custom kms key arn
-rosa_kms_key_arn: "" 
+#rosa_kms_key_arn: "" 
 
 # uncomment to pin to a version
 # rosa_version: 4.13.10

--- a/environment/private-link/group_vars/all.yaml
+++ b/environment/private-link/group_vars/all.yaml
@@ -1,7 +1,7 @@
 cluster_name: ansible-rosa-v1
 
-#rosa_private_link: true
-#rosa_sts: true
+rosa_private_link: false
+rosa_sts: true
 
 #set to false if you do not want to delete the account roles. Useful if different ROSA are installed using the same AWS account. Default to false (all the account roles are deleted)
 #delete_account_roles: false

--- a/environment/private-link/group_vars/all.yaml
+++ b/environment/private-link/group_vars/all.yaml
@@ -3,6 +3,9 @@ cluster_name: ansible-rosa-v1
 rosa_private_link: true
 rosa_sts: true
 
+#set to false if you do not want to delete the account roles. Useful if different ROSA are installed using the same AWS account. Default to false (all the account roles are deleted)
+#delete_account_roles: false
+
 #uncomment to add a custom kms key arn
 rosa_kms_key_arn: "" 
 

--- a/plugins/module_utils/ocm.py
+++ b/plugins/module_utils/ocm.py
@@ -285,7 +285,7 @@ class OcmClusterModule(object):
                     role_arn = params['role_arn'],
                     support_role_arn = params['support_role_arn'],
                 ),
-
+                
                 kms_key_arn=params['kms_key_arn'], 
                 
                 account_id = params['aws_account_id'],
@@ -349,6 +349,11 @@ class OcmClusterModule(object):
         )
 
         try:
+            # Check if kms_key_arn is not null or empty and remove it from param dict
+            # if kms_key_arn is == '' (user does not require a custom kms key) install will fail if kms_key_arn param is not removed
+            if cluster.aws.kms_key_arn == '':
+               cluster.aws.__setattr__("kms_key_arn", None)
+
             cluster_create = api_instance.api_clusters_mgmt_v1_clusters_post(cluster=cluster)
         except ApiException as e:
             return cluster.to_dict(), "Exception when calling DefaultApi->api_clusters_mgmt_v1_clusters_post: {}\n".format(e)

--- a/plugins/modules/ocm_cluster.py
+++ b/plugins/modules/ocm_cluster.py
@@ -240,6 +240,8 @@ def run_module():
     with ocm_client.ApiClient(OcmModule.ocm_authenticate()) as api_client:
         api_instance = ocm_client.DefaultApi(api_client)
 
+        
+  
         # Check to see if there is a cluster of the same name
         if not cluster_id:
             cluster_id, err = OcmClusterModule.get_cluster_id(api_instance, name)

--- a/roles/account_roles_delete/vars/main.yml
+++ b/roles/account_roles_delete/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 # vars file for roles/account-roles
+delete_account_roles: true

--- a/roles/cluster_create/tasks/main.yml
+++ b/roles/cluster_create/tasks/main.yml
@@ -87,7 +87,7 @@
         controlplane_iam_role: "arn:aws:iam::{{ aws_account_id }}:role/{{ rosa_account_roles_prefix }}-ControlPlane-Role"
         worker_iam_role: "arn:aws:iam::{{ aws_account_id }}:role/{{ rosa_account_roles_prefix }}-Worker-Role"
         operator_roles_prefix: "{{ rosa_operator_roles_prefix | default(cluster_name) }}"
-        kms_key_arn: "{{ rosa_kms_key_arn | default(omit) }}"
+        kms_key_arn: "{{ rosa_kms_key_arn | default(None) }}"
       register: _rosa_cluster
 
 - debug:


### PR DESCRIPTION
If more then one Rosa cluster is installed using the same AWS account, the account-roles must no be deleted. Added this functionality.

Fixed cluster creation error if the kms_key_arn is not defined.